### PR TITLE
Update for Magit 4.3.6

### DIFF
--- a/magit-tbdiff.el
+++ b/magit-tbdiff.el
@@ -189,9 +189,7 @@ otherwise."
         (magit-insert-heading)
         (while (not (or (eobp) (looking-at "^[^-+\s\\]")))
           (forward-line))
-        (oset section end (point))
-        (unless dual-color
-          (oset section washer 'magit-diff-paint-hunk))))
+        (oset section end (point))))
     t))
 
 (defun magit-tbdiff-wash (args)


### PR DESCRIPTION
`magit-diff-paint-hunk` was removed from Magit in magit/magit@c556fee1bd3ccc44da9f2322ec17dc5c3f0ef5be (“Generalize section painting”, 2025-05-18).  Painting of `hunk` sections is now handled automatically by the `magit-section-paint` generic function.