### PR TITLE
Fix diff rendering for hunks with magit 4.6+

### DIFF
--- a/magit-tbdiff.el
+++ b/magit-tbdiff.el
@@ -179,7 +179,7 @@ otherwise."
   ;; introduced by Git 2.23.0.
   (when (looking-at "^@@\\(?: \\(.*\\)\\)?")
     (let ((heading (match-string 0))
-          (value (match-string 1)))
+          (value (list (match-string 1))))
       (magit-delete-line)
       (magit-insert-section section ((eval (if dual-color 'tbdiff-hunk 'hunk))
                                      value)


### PR DESCRIPTION
Magit 4.6 calls `magit--meta-hunk-p` while highlighting hunk sections and expects their values to be lists. If we pass the heading string instead of a list we get a `wrong-type-argument` inside `magit--meta-hunk-p`.